### PR TITLE
fixed "show-recent" and "show-places" checkboxes

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -1364,8 +1364,8 @@ MyApplet.prototype = {
 
             this.settings = new Settings.AppletSettings(this, "StarkMenu@mintystark", instance_id);
 
-            this.settings.bindProperty(Settings.BindingDirection.IN, "show-recent", "showRecent", this._refreshPlacesAndRecent, null);
-            this.settings.bindProperty(Settings.BindingDirection.IN, "show-places", "showPlaces", this._refreshPlacesAndRecent, null);
+            this.settings.bindProperty(Settings.BindingDirection.IN, "show-recent", "showRecent", this._refreshApps, null);
+            this.settings.bindProperty(Settings.BindingDirection.IN, "show-places", "showPlaces", this._refreshApps, null);
 
             this.settings.bindProperty(Settings.BindingDirection.IN, "activate-on-hover", "activateOnHover", this._updateActivateOnHover, null);
             this._updateActivateOnHover();


### PR DESCRIPTION
The checkboxes "Show bookmarks and places" and "Show recent files" in the menusettings were broken, due to a not existing _refreshPlacesAndRecent-function.
