### PR TITLE
refresh menu if you change icon theme

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -1463,12 +1463,27 @@ MyApplet.prototype = {
 
             this.settings.bindProperty(Settings.BindingDirection.IN, "quicklink-options", "quicklinkOptions", this._updateQuickLinks, null);
             this._updateQuickLinks();
+            
+	    // We shouldn't need to call refreshAll() here... since we get a "icon-theme-changed" signal when CSD starts.
+            // The reason we do is in case the Cinnamon icon theme is the same as the one specificed in GTK itself (in .config)
+            // In that particular case we get no signal at all.
+            this._refreshAll();
 
-
+            St.TextureCache.get_default().connect("icon-theme-changed", Lang.bind(this, this.onIconThemeChanged));
+            
         }
         catch (e) {
             global.logError(e);
         }
+    },
+    
+    onIconThemeChanged: function() {
+        this._refreshAll();
+    },
+
+    _refreshAll: function() {
+        this._refreshApps();
+        this._refreshFavs();
     },
 
     openMenu: function() {


### PR DESCRIPTION
If you change your icon theme, the icons in StarkMenu will not be refreshed.
For example: Choose the Mint-X icons theme. Then look at your LibreOffice Writer icon in StarkMenu. Change your icons theme to HighContrast and look again at the LibreOffice Writer icon in StarkMenu. It still shows the icon from Mint-X.

This fix should solve this problem, so the StarkMenu refreshes after every change of the icons theme.

Again this fix is due to https://github.com/linuxmint/Cinnamon/tree/master/files/usr/share/cinnamon/applets/menu%40cinnamon.org
I just adopted it to StarkMenu.
