### PR TITLE
Fix missing home folder icon

### DIFF
--- a/CinnVIIStarkMenu@NikoKrause/3.2/settings-schema.json
+++ b/CinnVIIStarkMenu@NikoKrause/3.2/settings-schema.json
@@ -317,7 +317,7 @@
  },
  "quicklauncher-1-icon": {
     "type": "iconfilechooser",
-    "default" : "folder-home",
+    "default" : "user-home",
     "description" : "Quicklauncher icon",
     "tooltip" : "Select an icon file or type an icon name into the entry box for the quicklauncher",
     "dependency" : "quicklauncher-1-checkbox",


### PR DESCRIPTION
Using [freedesktop specification](https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html#names) standard icon name.