### PR TITLE
Improve search entry sizing

### DIFF
--- a/CinnVIIStarkMenu@NikoKrause/2.6/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/2.6/applet.js
@@ -1147,7 +1147,7 @@ TextBoxItem.prototype = {
         this.func = func;
         this.active = false;
         AppPopupSubMenuMenuItem.prototype._init.call(this, label);
-        
+
         this.addStyleClassName = addStyleClassName;
 
         this.actor.set_style_class_name('menu-category-button');
@@ -2352,10 +2352,10 @@ MyApplet.prototype = {
             //this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
             Mainloop.idle_add(Lang.bind(this, this._initial_cat_selection, n));
 
-            let favsWidth = 0.95 * (this.favsBox.get_allocation_box().x2 - this.favsBox.get_allocation_box().x1);
-            this.searchEntry.style = "width:" + favsWidth + "px; padding-left: 6px; padding-right: 6px;";
-            this.appsButton.box.style = "width:" + favsWidth + "px";
-            this.resultsFoundButton.box.style = "width:" + favsWidth + "px";
+            this.fit_favsbox(this.searchEntry);
+            this.fit_favsbox(this.appsButton.box);
+            this.fit_favsbox(this.resultsFoundButton.box);
+
         } else {
             this.actor.remove_style_pseudo_class('active');
             if (this.searchActive) {
@@ -2377,6 +2377,14 @@ MyApplet.prototype = {
         for (let i = start_index; i < n; i++) {
             this._applicationsButtons[i].actor.show();
         }
+    },
+
+    fit_favsbox: function(elem) {
+        let parent = elem.get_parent().get_theme_node();
+        let p_hpadding = parent.get_padding(St.Side.LEFT) + parent.get_padding(St.Side.RIGHT);
+        let favsbox_width = this.favsBox.get_allocation_box().x2 - this.favsBox.get_allocation_box().x1;
+
+        elem.set_width(favsbox_width - p_hpadding);
     },
 
     destroy: function() {
@@ -3594,9 +3602,7 @@ MyApplet.prototype = {
 
         this.appsBox = new St.BoxLayout({ vertical: true });
 
-        this.searchBox = new St.BoxLayout({ style_class: 'menu-search-box' });
-        this.searchBox.add_style_class_name("starkmenu-search-box");
-        this.searchBox.set_style("padding-right: 0px;padding-left: 0px;height:26px;");
+        this.searchBox = new St.BoxLayout({ style_class: 'starkmenu-search-box' });
 
         this.searchEntry = new St.Entry({ name: 'menu-search-entry',
                                      hint_text: _("Type to search..."),

--- a/CinnVIIStarkMenu@NikoKrause/3.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/3.2/applet.js
@@ -2383,10 +2383,9 @@ MyApplet.prototype = {
             //this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
             Mainloop.idle_add(Lang.bind(this, this._initial_cat_selection, n));
 
-            let favsWidth = 0.95 * (this.favsBox.get_allocation_box().x2 - this.favsBox.get_allocation_box().x1);
-            this.searchEntry.style = "width:" + favsWidth + "px; padding-left: 6px; padding-right: 6px;";
-            this.appsButton.box.style = "width:" + favsWidth + "px";
-            this.resultsFoundButton.box.style = "width:" + favsWidth + "px";
+            this.fit_favsbox(this.searchEntry);
+            this.fit_favsbox(this.appsButton.box);
+            this.fit_favsbox(this.resultsFoundButton.box);
 
         } else {
             if (this._appletEnterEventId > 0) {
@@ -2413,6 +2412,14 @@ MyApplet.prototype = {
         for (let i = start_index; i < n; i++) {
             this._applicationsButtons[i].actor.show();
         }
+    },
+
+    fit_favsbox: function(elem) {
+        let parent = elem.get_parent().get_theme_node();
+        let p_hpadding = parent.get_padding(St.Side.LEFT) + parent.get_padding(St.Side.RIGHT);
+        let favsbox_width = this.favsBox.get_allocation_box().x2 - this.favsBox.get_allocation_box().x1;
+
+        elem.set_width(favsbox_width - p_hpadding);
     },
 
     destroy: function() {
@@ -3599,9 +3606,7 @@ MyApplet.prototype = {
 
         this.appsBox = new St.BoxLayout({ vertical: true });
 
-        this.searchBox = new St.BoxLayout({ style_class: 'menu-search-box' });
-        this.searchBox.add_style_class_name("starkmenu-search-box");
-        this.searchBox.set_style("padding-right: 0px;padding-left: 0px;height:26px;");
+        this.searchBox = new St.BoxLayout({ style_class: 'starkmenu-search-box' });
 
         this.searchEntry = new St.Entry({ name: 'menu-search-entry',
                                      hint_text: _("Type to search..."),


### PR DESCRIPTION
Let themes define horizontal paddings. Improve width calculations instead of multiplying it by 0.95.

An example of improvement (left before, right after):
![screenshot from 2017-03-06 00-24-13](https://cloud.githubusercontent.com/assets/10391266/23592615/0570954c-0204-11e7-9860-dbebb1b4ea0d.png)
 
In general, themes are not affected by this change or they have improved padding glitches caused by the applet itself.

There must be a better way of setting widths than with CSS styles, I guess.