### PR TITLE
Fix small size after comming back from favorites

### DIFF
--- a/CinnVIIStarkMenu@NikoKrause/3.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/3.2/applet.js
@@ -3778,10 +3778,13 @@ MyApplet.prototype = {
             this.appsButton.icon.set_icon_name("go-previous");
             if(this.menuLayout == "stark-menu")
                 this.rightButtonsBox.actor.hide();
+            if (this._previousTreeSelectedActor)
+                this._previousTreeSelectedActor.style_class = "menu-category-button";
+            this._previousTreeSelectedActor = this._allAppsCategoryButton.actor;
+            this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
+            this._select_category(null, this._allAppsCategoryButton);
             this._resizeMenuSections();
             visiblePane = "apps";
-            if (this._previousTreeSelectedActor == null)
-                this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
         } else {
             this.leftPane.set_child(this.favsBox);
             this.separator.actor.show();


### PR DESCRIPTION
If the user left selected any category, the list size could be
smaller after coming back from the favorites section.
Selecting the 'all apps' category solves this because it has
the largest one.

This fixes a bug I introduced with my last PR.